### PR TITLE
feat: Implement Chat feature

### DIFF
--- a/assets/icons/resume record icon.svg
+++ b/assets/icons/resume record icon.svg
@@ -1,0 +1,10 @@
+<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="19" height="19" rx="9.5" fill="url(#paint0_linear_2112_1765)"/>
+<path d="M14.5561 8.81244C15.1514 9.11413 15.147 9.97295 14.5486 10.2684L7.15968 13.9162C6.62285 14.1813 5.99691 13.785 6.00001 13.1822L6.01896 9.49578L6.03791 5.8094C6.04101 5.20653 6.67099 4.81688 7.20506 5.08751L14.5561 8.81244Z" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+<defs>
+<linearGradient id="paint0_linear_2112_1765" x1="9.5" y1="0" x2="9.5" y2="19" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E4DB"/>
+<stop offset="1" stop-color="#00BBD3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/lib/core/constants/app_icons.dart
+++ b/lib/core/constants/app_icons.dart
@@ -34,7 +34,8 @@ class AppIcons {
   static const String arrowRight = 'assets/icons/arrow_right.svg';
   static const String arrowDown = 'assets/icons/arrow down icon.svg';
   static const String arrowUp = 'assets/icons/arrow_up.svg';
-  
+  static const String resumeRecord = 'assets/icons/resume record icon.svg';
+
   // Status Icons
   static const String heart = 'assets/icons/heart.svg';
   static const String star = 'assets/icons/star.svg';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -56,6 +56,7 @@ abstract class AppStrings {
   static const String welcomeBack = 'Hi, WelcomeBack';
   static const String userName = 'Jone Doe';
   static const String home = 'Home';
+  static const String chats = 'Chats';
   static const String messages = 'Messages';
   static const String profile = 'Profile';
   static const String myProfile = 'My Profile';
@@ -222,6 +223,8 @@ abstract class AppStrings {
   static const String filter = 'Filter';
   static const String topRating = 'Top Rating';
   static const String markAll = 'Mark All';
+  static const String searchForChats = 'Search for Your chats...';
+  static const String writeHere = 'Write Here...';
 
   
 

--- a/lib/core/reusable_componants/custom_app_bar.dart
+++ b/lib/core/reusable_componants/custom_app_bar.dart
@@ -121,4 +121,41 @@ class CustomAppBar {
       ),
     ),
   );
+
+
+  static PreferredSizeWidget chatAppBar(BuildContext context) => AppBar(
+    leadingWidth: 20.w,
+    toolbarHeight: 70.h,
+    actionsPadding: EdgeInsets.symmetric(horizontal: AppDimensions.padding16.w),
+    centerTitle: true,
+    leading: IconButton(onPressed: (){
+       Navigator.pop(context);
+    },icon:Icon(Icons.arrow_back_ios, size: AppDimensions.iconSize24.sp,)),
+    title: Text('Dr. John Doe'),
+    actions: [
+      CircleContainer(
+        child: CustomShader(
+          child: Icon(
+            Icons.phone_in_talk_outlined,
+            size: AppDimensions.iconSize16.sp,
+          ),
+        ),
+      ),
+
+      CircleContainer(
+        child: CustomShader(
+          child: Icon(Icons.videocam, size: AppDimensions.iconSize16.sp),
+        ),
+      ),
+    ],
+    flexibleSpace: Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: AppColors.mainGradient,
+        ),
+      ),
+    ),
+  );
 }

--- a/lib/core/routes/app_routes.dart
+++ b/lib/core/routes/app_routes.dart
@@ -14,6 +14,7 @@ import 'package:health_track/features/notification/presentation/pages/notificati
 import 'package:health_track/features/settings/presentation/pages/password_manger_screen.dart';
 import 'package:health_track/features/settings/presentation/pages/privacy_policy_screen.dart';
 import 'package:health_track/features/settings/presentation/pages/settings_screen.dart';
+import 'package:health_track/features/taps/chats_tap/presentation/pages/chat_screen.dart';
 import '../../features/app_entry/onBoarding/data/data_sources/on_boarding_local_data_source.dart';
 import '../../features/app_entry/onBoarding/presentation/pages/on_boarding_screen.dart';
 import '../../features/settings/presentation/pages/notification_setting_screen.dart';
@@ -42,6 +43,7 @@ abstract class AppRoutes {
   static const String paymentMethod = '/aboutUs';
   static const String privacyPolicy = '/privacyPolicy';
   static const String notification = '/notification';
+  static const String chatScreen = '/chatScreen';
 
 }
 final GoRouter appRouter = GoRouter(
@@ -140,6 +142,11 @@ final GoRouter appRouter = GoRouter(
       path: AppRoutes.notification,
       name: AppRoutes.notification,
       builder: (context, state) => NotificationScreen(),
+    ),
+    GoRoute(
+      path: AppRoutes.chatScreen,
+      name: AppRoutes.chatScreen,
+      builder: (context, state) => ChatScreen(),
     ),
 
     /*

--- a/lib/features/main_layout/presentation/pages/main_layout.dart
+++ b/lib/features/main_layout/presentation/pages/main_layout.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:health_track/core/core.dart';
+import 'package:health_track/features/taps/chats_tap/presentation/pages/chats_tap.dart';
 import 'package:health_track/features/taps/home_tap/presentation/pages/home_tap.dart';
 import 'package:health_track/features/taps/profile_tap/presentation/pages/profile_tap.dart';
 
@@ -19,7 +20,7 @@ class _MainLayoutState extends State<MainLayout> {
   final List<Widget> _pages = [
     // Add your pages here
     HomeTap(), // Placeholder for Home
-    Container(color: Colors.blue), // Placeholder for Messages
+    ChatsTap(), // Placeholder for Messages
     ProfileTap(), // Placeholder for Profile
     Container(color: Colors.yellow), // Placeholder for Calendar
   ];

--- a/lib/features/taps/chats_tap/data/data_sources/remote/chats_tap_remote_data_source.dart
+++ b/lib/features/taps/chats_tap/data/data_sources/remote/chats_tap_remote_data_source.dart
@@ -1,0 +1,3 @@
+abstract class ChatsTapRemoteDataSource {
+
+}

--- a/lib/features/taps/chats_tap/data/data_sources/remote/chats_tap_remote_data_source_impl.dart
+++ b/lib/features/taps/chats_tap/data/data_sources/remote/chats_tap_remote_data_source_impl.dart
@@ -1,0 +1,7 @@
+import 'package:injectable/injectable.dart';
+import '../../data_sources/remote/chats_tap_remote_data_source.dart';
+
+@LazySingleton(as: ChatsTapRemoteDataSource)
+class ChatsTapRemoteDataSourceImpl implements ChatsTapRemoteDataSource {
+
+}

--- a/lib/features/taps/chats_tap/data/repo/chats_tap_repo_impl.dart
+++ b/lib/features/taps/chats_tap/data/repo/chats_tap_repo_impl.dart
@@ -1,0 +1,7 @@
+import 'package:injectable/injectable.dart';
+import '../../domain/repo/chats_tap_repo.dart';
+
+@LazySingleton(as: ChatsTapRepo)
+class ChatsTapRepoImpl implements ChatsTapRepo {
+
+}

--- a/lib/features/taps/chats_tap/domain/repo/chats_tap_repo.dart
+++ b/lib/features/taps/chats_tap/domain/repo/chats_tap_repo.dart
@@ -1,0 +1,3 @@
+abstract class ChatsTapRepo {
+
+}

--- a/lib/features/taps/chats_tap/presentation/pages/chat_screen.dart
+++ b/lib/features/taps/chats_tap/presentation/pages/chat_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:health_track/core/constants/app_dimensions.dart';
+import 'package:health_track/core/constants/app_strings.dart';
+import 'package:health_track/core/reusable_componants/custom_app_bar.dart';
+import 'package:health_track/features/taps/chats_tap/presentation/widgets/chat_methods_container_widget.dart';
+import 'package:health_track/features/taps/chats_tap/presentation/widgets/chat_text_field_widget.dart';
+import 'package:health_track/features/taps/chats_tap/presentation/widgets/chats_list_widget.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../../../core/reusable_componants/circle_container.dart';
+import '../widgets/chat_massege_widget.dart';
+
+class ChatScreen extends StatelessWidget {
+  const ChatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar.chatAppBar(context),
+      body: Padding(
+        padding: REdgeInsets.symmetric(
+          vertical: AppDimensions.padding16.h,
+          horizontal: AppDimensions.padding24.w,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.max,
+          children: [
+            Expanded(child: ChatsListWidget()),
+            SizedBox(height: AppDimensions.padding16.h),
+            ChatMethodsContainerWidget()
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/taps/chats_tap/presentation/pages/chats_tap.dart
+++ b/lib/features/taps/chats_tap/presentation/pages/chats_tap.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:health_track/core/constants/app_dimensions.dart';
+import 'package:health_track/core/constants/app_images.dart';
+import 'package:health_track/core/constants/app_strings.dart';
+import 'package:health_track/core/reusable_componants/custom_app_bar.dart';
+import 'package:health_track/features/taps/chats_tap/presentation/widgets/chat_widget.dart';
+
+import '../../../../../core/constants/app_icons.dart';
+
+class ChatsTap extends StatelessWidget {
+  const ChatsTap({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CustomScrollView(
+
+        slivers: [
+          CustomAppBar.searchAppBar(
+              AppStrings.chats, AppStrings.searchForChats),
+          SliverPadding(padding: EdgeInsets.symmetric(
+              horizontal: AppDimensions.padding24.w,
+              vertical: AppDimensions.padding16.h),
+            sliver:SliverList.builder(itemBuilder: (context, index) => ChatWidget(),itemCount: 1,)
+            ,),
+
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/taps/chats_tap/presentation/widgets/chat_massege_widget.dart
+++ b/lib/features/taps/chats_tap/presentation/widgets/chat_massege_widget.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:health_track/core/constants/app_images.dart';
+import 'package:health_track/core/core.dart';
+import 'package:health_track/features/taps/chats_tap/presentation/widgets/chat_recored_widget.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../../../core/constants/app_dimensions.dart';
+import '../../../../../core/constants/app_strings.dart';
+
+class ChatMassageWidget extends StatelessWidget {
+  const ChatMassageWidget({super.key,required this.isSender, required this.isRecord});
+  final bool isSender;
+  final bool isRecord;
+  @override
+  Widget build(BuildContext context) {
+    return   Container(
+      width: 220.w,
+
+      alignment: isSender?Alignment.centerRight:Alignment.centerLeft,
+      padding: REdgeInsets.symmetric(horizontal: AppDimensions.padding24.w,vertical: AppDimensions.padding8.h),
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+          color: AppColors.surface,
+
+          borderRadius: BorderRadius.only(bottomLeft:isSender?Radius.circular(AppDimensions.radius20.r):Radius.zero,topLeft: Radius.circular(AppDimensions.radius20.r),topRight: Radius.circular(AppDimensions.radius20.r),bottomRight: isSender ?Radius.zero:Radius.circular(AppDimensions.radius20.r.r) )
+          , border: Border.all(color:isSender?AppColors.surface: AppColors.primary)
+      ),
+      child:  isRecord?ChatRecordWidget(isSender: isSender,):
+
+      Text(AppStrings.loremIpsumLong,style: Theme.of(context).textTheme.labelLarge),
+    );
+  }
+}

--- a/lib/features/taps/chats_tap/presentation/widgets/chat_methods_container_widget.dart
+++ b/lib/features/taps/chats_tap/presentation/widgets/chat_methods_container_widget.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../../../core/constants/app_dimensions.dart';
+import '../../../../../core/reusable_componants/circle_container.dart';
+import 'chat_text_field_widget.dart';
+
+class ChatMethodsContainerWidget extends StatelessWidget {
+  const ChatMethodsContainerWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: REdgeInsets.symmetric(
+        horizontal: AppDimensions.padding16.w,
+        vertical: AppDimensions.padding12.h,
+      ),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(colors: AppColors.mainGradient),
+        color: AppColors.surface,
+      ),
+      child: Row(
+        children: [
+          CircleContainer(
+            child: Icon(
+              Icons.attach_file,
+              color: AppColors.primary,
+              size: 27.sp,
+            ),
+          ),
+          SizedBox(width: AppDimensions.sizedBox6.w),
+
+          Expanded(
+            child: ChatTextFieldWidget(),
+          ),
+          SizedBox(width: AppDimensions.sizedBox6.w),
+          CircleContainer(
+            child: Icon(
+              Icons.send_rounded,
+              color: AppColors.primary,
+              size: 27.sp,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/taps/chats_tap/presentation/widgets/chat_recored_widget.dart
+++ b/lib/features/taps/chats_tap/presentation/widgets/chat_recored_widget.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../../../core/constants/app_dimensions.dart';
+import '../../../../../core/constants/app_icons.dart';
+import '../../../../../core/constants/app_images.dart';
+
+class ChatRecordWidget extends StatelessWidget {
+   const ChatRecordWidget({super.key, required this.isSender});
+final bool isSender;
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: isSender?TextDirection.rtl:TextDirection.ltr,
+      child: Row(
+        children: [
+          Image.asset(AppImages.doctor1,height: 35.h,fit: BoxFit.cover,),
+          SizedBox(width: AppDimensions.sizedBox6.w,),
+          SvgPicture.asset(AppIcons.resumeRecord),
+          SizedBox(width: AppDimensions.sizedBox6.w,),
+          Expanded(child: SizedBox(height: 5.h,
+              child: LinearProgressIndicator( valueColor:AlwaysStoppedAnimation(AppColors.secondary,),value:.8,stopIndicatorRadius: 100.r,stopIndicatorColor: Colors.white,color: Colors.transparent,backgroundColor: AppColors.background, )))
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/taps/chats_tap/presentation/widgets/chat_text_field_widget.dart
+++ b/lib/features/taps/chats_tap/presentation/widgets/chat_text_field_widget.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../../../core/constants/app_dimensions.dart';
+import '../../../../../core/constants/app_strings.dart';
+
+class ChatTextFieldWidget extends StatelessWidget {
+  const ChatTextFieldWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      style: Theme.of(context).textTheme.labelLarge,
+      decoration: InputDecoration(
+        hintStyle: Theme.of(context).textTheme.labelMedium
+            ?.copyWith(fontWeight: FontWeight.w400),
+        suffixIconConstraints: BoxConstraints(
+          maxHeight: 40.h,
+          maxWidth: 40.w,
+        ),
+        contentPadding: REdgeInsets.symmetric(
+          horizontal: AppDimensions.padding16.w,
+          vertical: AppDimensions.padding8.h,
+        ),
+        suffixIcon: Icon(
+          Icons.mic_none_outlined,
+          color: AppColors.primary,
+        ),
+        constraints: BoxConstraints(maxHeight: 40.h),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(
+            AppDimensions.radius50.r,
+          ),
+          borderSide: BorderSide(color: Colors.transparent),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(
+            AppDimensions.radius50.r,
+          ),
+          borderSide: BorderSide(color: Colors.transparent),
+        ),
+        hintText: AppStrings.writeHere,
+        border: InputBorder.none,
+      ),
+    );
+  }
+}

--- a/lib/features/taps/chats_tap/presentation/widgets/chat_widget.dart
+++ b/lib/features/taps/chats_tap/presentation/widgets/chat_widget.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../../core/constants/app_images.dart';
+import '../../../../../core/routes/app_routes.dart';
+
+class ChatWidget extends StatelessWidget {
+  const ChatWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: (){
+GoRouter.of(context).push(AppRoutes.chatScreen);
+      },
+      contentPadding: EdgeInsets.zero,
+        leading: Image.asset(AppImages.doctor1),
+        title: FittedBox(child: Text('Dr. John Doe',style: Theme.of(context).textTheme.labelLarge,)),
+        subtitle: Text('Hello, how can I help you?',style: Theme.of(context).textTheme.headlineSmall,maxLines: 1,overflow: TextOverflow.ellipsis,),
+        trailing: Text('2:30 PM')
+    );
+  }
+}

--- a/lib/features/taps/chats_tap/presentation/widgets/chats_list_widget.dart
+++ b/lib/features/taps/chats_tap/presentation/widgets/chats_list_widget.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'chat_massege_widget.dart';
+
+class ChatsListWidget extends StatelessWidget {
+   ChatsListWidget({super.key});
+  bool isSender = false;
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+
+itemCount: 11,
+      itemBuilder: (context, index) {
+        isSender=!isSender;
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: isSender
+              ? CrossAxisAlignment.end
+              : CrossAxisAlignment.start,
+          children: [
+            Flexible(child: ChatMassageWidget(isSender: isSender,isRecord: index%7==0,)),
+
+            Align(
+              alignment: isSender
+                  ? Alignment.centerRight
+                  : Alignment.centerLeft,
+              child: Text(
+                '2:30 PM',
+                style: Theme.of(context).textTheme.labelSmall,
+                textAlign: isSender
+                    ? TextAlign.right
+                    : TextAlign.left,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
+add `ChatScreen` for individual chat conversations +add `ChatsTap` to display a list of all chats
+create various chat widgets including:
    +`ChatMassageWidget` for displaying individual messages
    +`ChatRecordWidget` for voice message UI
    +`ChatMethodsContainerWidget` for message input and actions (attach, send)
    +`ChatTextFieldWidget` for the message input field
    +`ChatWidget` for list items in the main chats list
    +`ChatsListWidget` to display the conversation message list
+add a new route for the `ChatScreen`
+add a new "resume record" icon and update `AppIcons` +add new strings for the chat feature
+add a dedicated `chatAppBar` to `CustomAppBar`

+refactor: Integrate `ChatsTap` into the main layout